### PR TITLE
fix: 修复长会话导出/树视图爆栈 (Maximum call stack size exceeded)

### DIFF
--- a/ClaudePowerestManager&Enhancer.user.js
+++ b/ClaudePowerestManager&Enhancer.user.js
@@ -950,36 +950,41 @@
                 childrenMap[parentUuid].sort((a, b) => new Date(nodesCopy[a].created_at) - new Date(nodesCopy[b].created_at));
             }
 
-            function assignIdsRecursive(nodeUuid, prefix) {
-                if (!nodesCopy[nodeUuid]) return;
-                const node = nodesCopy[nodeUuid];
-                // 在副本上添加 tree_id
-                node.tree_id = prefix;
+            // 迭代版：用显式栈替代递归，避免在长会话上爆栈 (Maximum call stack size exceeded)
+            function assignIdsIterative(rootUuid, rootPrefix) {
+                if (!nodesCopy[rootUuid]) return;
+                const stack = [[rootUuid, rootPrefix]];
+                while (stack.length > 0) {
+                    const [nodeUuid, prefix] = stack.pop();
+                    const node = nodesCopy[nodeUuid];
+                    if (!node) continue;
+                    node.tree_id = prefix;
 
-                const children = childrenMap[nodeUuid] || [];
-                let normalIndex = 0;
-                let dirtyCount = 1;
-
-                children.forEach((childUuid) => {
-                    const childNode = nodesCopy[childUuid];
-                    if (!childNode) return;
-
-                    // 检测脏数据：标记了 _isDirtyData 的节点
-                    const isDirtyData = childNode._isDirtyData;
-
-                    if (isDirtyData) {
-                        assignIdsRecursive(childUuid, `${prefix}-F${dirtyCount}`);
-                        dirtyCount++;
-                    } else {
-                        assignIdsRecursive(childUuid, `${prefix}-${normalIndex}`);
-                        normalIndex++;
+                    const children = childrenMap[nodeUuid] || [];
+                    let normalIndex = 0;
+                    let dirtyCount = 1;
+                    const childEntries = [];
+                    for (const childUuid of children) {
+                        const childNode = nodesCopy[childUuid];
+                        if (!childNode) continue;
+                        if (childNode._isDirtyData) {
+                            childEntries.push([childUuid, `${prefix}-F${dirtyCount}`]);
+                            dirtyCount++;
+                        } else {
+                            childEntries.push([childUuid, `${prefix}-${normalIndex}`]);
+                            normalIndex++;
+                        }
                     }
-                });
+                    // 逆序入栈，保证 pop 顺序与原递归的 forEach 一致（深度优先、左到右）
+                    for (let i = childEntries.length - 1; i >= 0; i--) {
+                        stack.push(childEntries[i]);
+                    }
+                }
             }
 
             const rootNodes = childrenMap[Config.INITIAL_PARENT_UUID] || [];
             rootNodes.forEach((rootUuid, index) => {
-                assignIdsRecursive(rootUuid, `root-${index}`);
+                assignIdsIterative(rootUuid, `root-${index}`);
             });
 
             return { nodes: nodesCopy, childrenMap, rootNodes };
@@ -1943,7 +1948,7 @@
             const orgUuid = await ClaudeAPI.getOrgUuid();
             const baseUrl = window.location.origin;
 
-            const renderNodeRecursive = (nodeUuid, indentLevel) => {
+            const renderNode = (nodeUuid, indentLevel) => {
                 const node = nodes[nodeUuid];
                 if (!node) return;
 
@@ -2049,9 +2054,21 @@
                 }
 
                 container.appendChild(nodeElement);
-                (childrenMap[nodeUuid] || []).forEach(childUuid => renderNodeRecursive(childUuid, indentLevel + 1));
             };
-            rootNodes.forEach(rootUuid => renderNodeRecursive(rootUuid, 0));
+            // 迭代版深度优先遍历：用显式栈替代递归，避免在长会话上爆栈
+            const stack = [];
+            for (let i = rootNodes.length - 1; i >= 0; i--) {
+                stack.push([rootNodes[i], 0]);
+            }
+            while (stack.length > 0) {
+                const [nodeUuid, indentLevel] = stack.pop();
+                renderNode(nodeUuid, indentLevel);
+                const children = childrenMap[nodeUuid] || [];
+                // 逆序入栈，保证 pop 顺序与原递归的 forEach 一致（深度优先、左到右）
+                for (let i = children.length - 1; i >= 0; i--) {
+                    stack.push([children[i], indentLevel + 1]);
+                }
+            }
         }
     };
 


### PR DESCRIPTION
## 问题 / Problem

在长会话（节点树主干层数较多）上，单条导出失败并提示：

> 导出失败 (1/1): Maximum call stack size exceeded

打开"树视图"在同类会话上也会抛同一个错。

## 根因 / Root cause

两个对节点树做**无深度限制递归遍历**的函数：

- `ClaudeAPI.buildConversationTree` → `assignIdsRecursive`
- `SharedLogic.renderTreeView` → `renderNodeRecursive`

当会话主干长度逼近 V8 默认调用栈上限（≈1~1.5 万层）时，递归直接触发 `RangeError: Maximum call stack size exceeded`。

`assignIdsRecursive` 在每次 `getConversationHistory` 中都会被调用，因此**任何**导出路径（原始 / 自定义 / 单条 / 批量）在这种会话上都会失败。

## 改动 / Fix

两处都改为基于显式栈的迭代实现：

- 用 `stack = [[uuid, prefix]]` + while 循环替代递归
- 子节点逆序入栈，保证 pop 顺序与原 `forEach` 一致（深度优先、左到右）
- `tree_id` 命名规则、DOM 追加顺序、对外行为完全等价

diff 仅 +45 / -28，无新依赖、无 API 变更。

## 测试 / Testing

- ✅ 在原本必报错的长会话上单条「原始导出」「自定义导出」均成功
- ✅ 短会话回归正常
- ✅ 树视图：节点 `tree_id` (root-0 / root-0-0 / root-0-1-F1) 与原版一致，缩进、点击切分支均正常
- ✅ 批量导出进度 (1/N..N/N) 推进正常

---

**EN summary**: Replace two unbounded-depth tree recursions (`assignIdsRecursive` in `buildConversationTree`, `renderNodeRecursive` in `renderTreeView`) with explicit-stack iteration. Unblocks export and tree view on long conversations where the call-stack limit was previously exceeded. Behavior is equivalent — same depth-first order, same `tree_id` scheme, same DOM append order.